### PR TITLE
[BUG_FIX][print.c] Taking out the malloc and free

### DIFF
--- a/tools/print.c
+++ b/tools/print.c
@@ -762,12 +762,12 @@ void print_json_schema_col(int tbl, char *colName, char *colType)
 }
 void print_json_schema_end(int tbl, char *colName, char *colType)
 {
+	char writebuf[256];
 	tdef *pTdef = getSimpleTdefsByNumber(tbl);
 
 	/* write buffer memory allocation */
 	size_t colNameLen = strlen(colName);
 	size_t colTypeLen = strlen(colType);
-	char *writebuf = malloc(colNameLen + colTypeLen + 6);
 
 	/* fill the write buffer */
 	strcpy(writebuf, "\"");
@@ -779,6 +779,5 @@ void print_json_schema_end(int tbl, char *colName, char *colType)
 	fputs(writebuf, fpSchemaOutfile);
 
 	fflush(fpSchemaOutfile);
-	free(writebuf);
 	SCHEMA_W = 0;
 }


### PR DESCRIPTION
The error 
``` C
malloc.c:2401: sysmalloc: Assertion `(old_top == initial_top (av) && old_size == 0) || ((unsigned long) (old_size) >= MINSIZE && prev_inuse (old_top) && ((unsigned long) old_end & (pagesize - 1)) == 0)' failed.
```

happens when the store_sales and store_returns tables are being generated.  It might have something to do with the malloc() and free being shared incorrectly so we will just let the stack contain the char array to hold with write buffer. 